### PR TITLE
chore: votes inspector for all validators  

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,19 @@ $ python3 votes_inspector.py --network mainnet
 $ python3 votes_inspector.py
 ```
 
-## WEB Interface
-<!-- TODO: update -->
+
+## [Historical Oracle Votes Inspector](./inspector_go/README.md)
+
+### Build 
+```bash
+$ cd inspector_go 
+// build the binary
+$ make build
+```
+
+### How to run ? 
+
+
+```bash
+$ ./build/price_inspector --config <CONFIG.yaml> --network canon
+```

--- a/inspector_go/Makefile
+++ b/inspector_go/Makefile
@@ -1,0 +1,6 @@
+
+build:
+	go build -o ./build/ .
+
+clean:
+	rm -rf ./build

--- a/inspector_go/README.md
+++ b/inspector_go/README.md
@@ -3,6 +3,8 @@
 
 ## Configuration 
 
+> Note: if there is no validators list on configuration, it will inspect votes for all validators 
+
 1. Add validator's info for checking missing oracle votes
 2. Add a window parameter to specify the number of blocks to check from the latest height
 
@@ -17,11 +19,15 @@ validators:
 window: 20
 networks:
   canon:
-    rpc: http://localhost:26657
-    grpc: http://localhost:9090
+    rpc: https://canon-4.rpc.network.umee.cc:443
+    grpc: tcp://canon-4.network.umee.cc:11000
   mainnet:
     rpc: http://umee.rpc.m.stavr.tech:10457
     grpc: umee-grpc.polkachu.com:13690
+  local:
+    rpc: http://localhost:26657
+    grpc: http://localhost:9090
+
 
 ``````
 

--- a/inspector_go/config.yaml
+++ b/inspector_go/config.yaml
@@ -7,8 +7,11 @@ validators:
 window: 20
 networks:
   canon:
-    rpc: http://localhost:26657
-    grpc: http://localhost:9090
+    rpc: https://canon-4.rpc.network.umee.cc:443
+    grpc: tcp://canon-4.network.umee.cc:11000
   mainnet:
     rpc: http://umee.rpc.m.stavr.tech:10457
     grpc: umee-grpc.polkachu.com:13690
+  local:
+    rpc: http://localhost:26657
+    grpc: http://localhost:9090

--- a/inspector_go/config/types.go
+++ b/inspector_go/config/types.go
@@ -52,6 +52,10 @@ type Configuration struct {
 			RPC  string `json:"rpc"`
 			GRPC string `json:"grpc"`
 		} `json:"mainnet"`
+		Local struct {
+			RPC  string `json:"rpc"`
+			GRPC string `json:"grpc"`
+		} `json:"local"`
 	} `json:"networks"`
 }
 

--- a/inspector_go/inspector.go
+++ b/inspector_go/inspector.go
@@ -34,9 +34,18 @@ func StartInspector(cfg config.Configuration, rpcUri, grpcUri string) error {
 	votes := make(map[string]config.ValidatorsVotes)
 	vInfo := make(map[string]string)
 
-	for _, v := range cfg.Validators {
-		votes[v.Validator] = config.NewValidatorVotes(v.Validator, expectedNoOfVotes)
-		vInfo[v.Validator] = v.Moniker
+	if len(cfg.Validators) == 0 {
+		log.Println("ℹ️ Getting all staking validators...")
+		validators := rpc.GetValidators(codec, grpcUri)
+		for _, val := range validators {
+			votes[val.OperatorAddress] = config.NewValidatorVotes(val.OperatorAddress, expectedNoOfVotes)
+			vInfo[val.OperatorAddress] = val.GetMoniker()
+		}
+	} else {
+		for _, v := range cfg.Validators {
+			votes[v.Validator] = config.NewValidatorVotes(v.Validator, expectedNoOfVotes)
+			vInfo[v.Validator] = v.Moniker
+		}
 	}
 
 	for i := lastBlockHeight; i < latestBlockHeight; i++ {

--- a/inspector_go/main.go
+++ b/inspector_go/main.go
@@ -42,13 +42,13 @@ func main() {
 				rpc = cfg.Networks.Local.RPC
 				grpc = cfg.Networks.Local.GRPC
 			default:
-				log.Fatalf("this netwokr %s is not supported", network)
+				log.Fatalf("this network %s is not supported", network)
 			}
 			return StartInspector(cfg, rpc, grpc)
 		},
 	}
 
-	rootCmd.Flags().String(config.Network, "canon", "Network to use (canon/mainnet/local)")
+	rootCmd.Flags().String(config.Network, "canon", "Network to use  (canon, mainnet or local)")
 	rootCmd.Flags().String(config.Config, "config.json", "Path to the configuration file")
 
 	if err := rootCmd.Execute(); err != nil {

--- a/inspector_go/main.go
+++ b/inspector_go/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -29,17 +30,25 @@ func main() {
 			if err != nil {
 				return err
 			}
-			rpc := cfg.Networks.Canon.RPC
-			grpc := cfg.Networks.Canon.GRPC
-			if network == "mainnet" {
+			var rpc, grpc string
+			switch network {
+			case "mainnet":
 				rpc = cfg.Networks.Mainnet.RPC
 				grpc = cfg.Networks.Mainnet.GRPC
+			case "canon":
+				rpc = cfg.Networks.Canon.RPC
+				grpc = cfg.Networks.Canon.GRPC
+			case "local":
+				rpc = cfg.Networks.Local.RPC
+				grpc = cfg.Networks.Local.GRPC
+			default:
+				log.Fatalf("this netwokr %s is not supported", network)
 			}
 			return StartInspector(cfg, rpc, grpc)
 		},
 	}
 
-	rootCmd.Flags().String(config.Network, "canon", "Network to use (canon/mainnet)")
+	rootCmd.Flags().String(config.Network, "canon", "Network to use (canon/mainnet/local)")
 	rootCmd.Flags().String(config.Config, "config.json", "Path to the configuration file")
 
 	if err := rootCmd.Execute(); err != nil {

--- a/inspector_go/rpc/grpc_client.go
+++ b/inspector_go/rpc/grpc_client.go
@@ -5,18 +5,32 @@ import (
 	"os"
 	"time"
 
+	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	"github.com/umee-network/umee/v6/sdkclient/query"
 	otypes "github.com/umee-network/umee/v6/x/oracle/types"
 )
 
-// GetOracleGrpcClient returns a gRPC client for querying the Oracle module.
-// It takes the gRPC endpoint as input and returns the Oracle query client.
-func GetOracleGrpcClient(grpcEndpoint string) otypes.QueryClient {
+func queryClient(grpcEndpoint string) *query.Client {
 	logger := log.New(os.Stderr, "chain-client", log.LstdFlags)
 	queryClient, err := query.NewClient(logger, grpcEndpoint, 15*time.Second)
 	if err != nil {
 		log.Fatalf("Failed to initalize the query client %s and Error:  %s", grpcEndpoint, err.Error())
 	}
 
-	return otypes.NewQueryClient(queryClient.GrpcConn)
+	return queryClient
+}
+
+// GetOracleGrpcClient returns a gRPC client for querying the Oracle module.
+// It takes the gRPC endpoint as input and returns the Oracle query client.
+func GetOracleGrpcClient(grpcEndpoint string) otypes.QueryClient {
+	client := queryClient(grpcEndpoint)
+	return otypes.NewQueryClient(client.GrpcConn)
+}
+
+// GetStakingGrpcClient returns a gRPC client for querying the staking module.
+// It takes the gRPC endpoint as input and returns the staking query client.
+func GetStakingGrpcClient(grpcEndpoint string) stypes.QueryClient {
+	client := queryClient(grpcEndpoint)
+	return stypes.NewQueryClient(client.GrpcConn)
 }


### PR DESCRIPTION
If there is no validators list on config, inspector will check the votes for all validators 

Example config:
```yaml
---
validators:
window: 20
networks:
  canon:
    rpc: https://canon-4.rpc.network.umee.cc:443
    grpc: tcp://canon-4.network.umee.cc:11000
  mainnet:
    rpc: http://umee.rpc.m.stavr.tech:10457
    grpc: umee-grpc.polkachu.com:13690
  local:
    rpc: http://localhost:26657
    grpc: http://localhost:9090

```